### PR TITLE
puppet_forge: Allow 3.x / fix broken Raketask example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The metadata-json-deps tool validates dependencies in `metadata.json` files in P
 
 ## Compatibility
 
-metadata-json-deps is compatible with Ruby versions 2.0.0 and newer.
+metadata-json-deps is compatible with Ruby versions 2.4.0 and newer.
 
 ## Installation
 
@@ -44,6 +44,6 @@ require 'metadata_json_deps'
 desc 'Run metadata-json-deps'
 task :metadata_deps do
   files = FileList['modules/*/metadata.json']
-  MetadataJsonDeps::Runner.run(files)
+  MetadataJsonDeps::run(files)
 end
 ```

--- a/metadata_json_deps.gemspec
+++ b/metadata_json_deps.gemspec
@@ -12,8 +12,9 @@ Gem::Specification.new do |s|
   s.metadata    = { 'source_code_uri' => 'https://github.com/ekohl/metadata_json_deps' }
   s.executables << 'metadata-json-deps'
 
-  s.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
+  # puppet_forge requires Ruby 2.4
+  s.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
-  s.add_runtime_dependency 'puppet_forge', '~> 2.2'
+  s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 4'
   s.add_runtime_dependency 'puppet_metadata', '~> 0.3.0'
 end


### PR DESCRIPTION
I tested this on the bird module
```console
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $ git diff
diff --git a/Gemfile b/Gemfile
index 930d8da..353a85e 100644
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem 'coveralls',                 :require => false
   gem 'simplecov-console',         :require => false
   gem 'puppet-lint-param-docs',    :require => false
+  gem 'metadata_json_deps', git: 'https://github.com/bastelfreak/metadata_json_deps', branch: '3'
 end
 
 group :development do
diff --git a/Rakefile b/Rakefile
index c84a24c..5879e4a 100644
--- a/Rakefile
+++ b/Rakefile
@@ -61,4 +61,15 @@ begin
 
 rescue LoadError
 end
+
+begin
+  require 'metadata_json_deps'
+
+  desc 'Run metadata-json-deps'
+  task :metadata_deps do
+    files = FileList['metadata.json']
+    MetadataJsonDeps::run(files)
+  end
+rescue LoadError
+end
 # vim: syntax=ruby
diff --git a/metadata.json b/metadata.json
index dd9a75a..400591d 100644
--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 8.0.0"
+      "version_requirement": ">= 4.25.0 < 7.0.0"
     }
   ],
   "requirements": [
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $ bundle exec rake metadata_deps
Checking metadata.json
  puppetlabs/stdlib (>= 4.25.0 < 7.0.0) doesn't match 7.1.0
bastelfreak@bastelfreak-nb ~/code/modulesync_config/modules/voxpupuli/puppet-bird $
```