### PR TITLE
puppet_metadata: Allow 1.x

### DIFF
--- a/metadata_json_deps.gemspec
+++ b/metadata_json_deps.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
   s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 4'
-  s.add_runtime_dependency 'puppet_metadata', '~> 0.3.0'
+  s.add_runtime_dependency 'puppet_metadata', '>= 0.3.0', '< 2'
 end


### PR DESCRIPTION
version 1.0.0 of puppet_metadata was released today. We can update the
dependency to allow the new version.