### PR TITLE
Add a bump-dependency-upper-bound script

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ On the command line, run `metadata-json-deps` with the path(s) of your `metadata
 metadata-json-deps /path/to/metadata.json
 ```
 
+Example output:
+
+```console
+$ metadata-json-deps modules/*/*/metadata.json
+Checking modules/theforeman/puppet-candlepin/metadata.json
+  puppetlabs/stdlib (>= 4.2.0 < 8.0.0) doesn't match 8.1.0
+  puppet/extlib (>= 3.0.0 < 6.0.0) doesn't match 6.0.0
+Checking modules/theforeman/puppet-certs/metadata.json
+  puppetlabs-stdlib (>= 4.25.0 < 8.0.0) doesn't match 8.1.0
+  puppet-extlib (>= 3.0.0 < 6.0.0) doesn't match 6.0.0
+Checking modules/theforeman/puppet-dhcp/metadata.json
+Checking modules/theforeman/puppet-dns/metadata.json
+```
+
 It can also be run verbosely to show valid dependencies:
 
 ```shell
@@ -46,4 +60,20 @@ task :metadata_deps do
   files = FileList['modules/*/metadata.json']
   MetadataJsonDeps::run(files)
 end
+```
+
+### Bumping dependency upper bounds
+
+After detecting outdated dependencies, it's important to do something about this. Taking the earlier example, you can see some modules should allow newer dependencies (candlepin and certs) while others are up to date (dhcp and dns).
+
+The next step is to look into the newer dependencies. In this case stdlib and extlib had a major version bump. It is then important to look at the changes and see if it does affect modules. Sometimes it doesn't, like when a module drops support for Puppet 5 but our modules already dropped Puppet 5. In that case, it's safe to raise the upper version bound.
+
+To update the upper bounds, [bump-dependency-upper-bound](https://github.com/voxpupuli/modulesync_config/blob/master/bin/bump-dependency-upper-bound) can be used. For example, to allow puppetlabs/stdlib 8.x, the new upper bound is 9.0.0:
+
+```console
+$ bump-dependency-upper-bound puppetlabs/stdlib 9.0.0 modules/*/*/metadata.json
+Updated modules/theforeman/puppet-candlepin/metadata.json: '>= 4.2.0 < 8.0.0' to '>= 4.2.0 < 9.0.0'
+Updated modules/theforeman/puppet-certs/metadata.json: '>= 4.25.0 < 8.0.0' to '>= 4.25.0 < 9.0.0'
+modules/theforeman/puppet-dhcp/metadata.json already matches 9.0.0
+modules/theforeman/puppet-dns/metadata.json already matches 9.0.0
 ```

--- a/bin/bump-dependency-upper-bound
+++ b/bin/bump-dependency-upper-bound
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+require 'optparse'
+require 'metadata_json_deps'
+
+def main
+  parser = OptionParser.new do |opts|
+    opts.banner = "Usage: #{opts.program_name} module_name new_upper_bound metadata"
+  end
+
+  parser.parse!
+  if ARGV.length < 3
+    STDERR.puts parser.help
+    exit 1
+  end
+
+  module_name, upper_bound, *paths = ARGV
+  module_name = PuppetForge::V3.normalize_name(module_name)
+  paths.each do |path|
+    begin
+      old, new = MetadataJsonDeps.bump_dependency(path, module_name, upper_bound)
+      if old != new
+        puts "Updated #{path}: '#{old}' to '#{new}'"
+      else
+        puts "#{path} already matches #{upper_bound}"
+      end
+    rescue Exception => e
+      puts "Failed to update #{path}: #{e}"
+    end
+  end
+end
+
+main

--- a/lib/metadata_json_deps.rb
+++ b/lib/metadata_json_deps.rb
@@ -35,6 +35,44 @@ module MetadataJsonDeps
     puts result.to_yaml
   end
 
+  # Bump a dependency in a filename
+  #
+  # @param [String] filename A path to a metadata file. An error is raised if
+  #   it's invalid metadata.
+  # @param [String] module_name The module name listed in dependencies. It must
+  #   be normalized to the forge style (using a dash). It can fall back to a
+  #   slash if metadata uses a slash.
+  # @param [String] upper_bound The new upper bound for the module name
+  # @return [Array<String>] An array with the old and new version. Can be used
+  #   to determine if a change was made.
+  # @see PuppetMetadata.read
+  def self.bump_dependency(filename, module_name, upper_bound)
+    metadata = PuppetMetadata.read(filename)
+
+    requirement = metadata.dependencies[module_name]
+    unless requirement
+      # TODO: normalize keys in puppet_metadata so we don't need 2 lookups?
+      module_name = module_name.tr('-', '/')
+      requirement = metadata.dependencies[module_name]
+      raise Exception.new("Dependency #{module_name} not found") unless requirement
+    end
+
+    return [requirement.to_s, requirement.to_s] if requirement.end == upper_bound
+
+    new = ">= #{requirement.begin} < #{upper_bound}"
+
+    new_metadata = metadata.metadata.clone
+    new_metadata['dependencies'].each do |dependency|
+      if dependency['name'] == module_name
+        dependency['version_requirement'] = new
+      end
+    end
+
+    File.write(filename, JSON.pretty_generate(new_metadata) + "\n")
+
+    [requirement.to_s, new]
+  end
+
   def self.run(filenames, verbose = false)
     forge = ForgeVersions.new
 

--- a/metadata_json_deps.gemspec
+++ b/metadata_json_deps.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['README.md']
   s.homepage    = 'https://github.com/ekohl/metadata_json_deps'
   s.metadata    = { 'source_code_uri' => 'https://github.com/ekohl/metadata_json_deps' }
+  s.executables << 'bump-dependency-upper-bound'
   s.executables << 'generate-fixtures-yaml'
   s.executables << 'metadata-json-deps'
 


### PR DESCRIPTION
With this script the gem can be used to both detect and update outdated dependencies in metadata.

See the README for detailed usage.

This is to replace https://github.com/voxpupuli/modulesync_config/blob/master/bin/bump-dependency-upper-bound and make it usable outside of the modulesync config.