### PR TITLE
Make the script fail with an exit code

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ require 'metadata_json_deps'
 desc 'Run metadata-json-deps'
 task :metadata_deps do
   files = FileList['modules/*/metadata.json']
-  MetadataJsonDeps::run(files)
+  abort if MetadataJsonDeps::run(files)
 end
 ```
 

--- a/bin/metadata-json-deps
+++ b/bin/metadata-json-deps
@@ -8,4 +8,4 @@ OptionParser.new do |opts|
   opts.on("-v", "--[no-]verbose", "Run verbosely")
 end.parse!(into: options)
 
-MetadataJsonDeps.run(ARGV, options[:verbose])
+exit(MetadataJsonDeps.run(ARGV, options[:verbose]))

--- a/lib/metadata_json_deps.rb
+++ b/lib/metadata_json_deps.rb
@@ -76,6 +76,8 @@ module MetadataJsonDeps
   def self.run(filenames, verbose = false)
     forge = ForgeVersions.new
 
+    exit_code = 0
+
     filenames.each do |filename|
       puts "Checking #{filename}"
       metadata = PuppetMetadata.read(filename)
@@ -84,6 +86,7 @@ module MetadataJsonDeps
         mod = forge.get_module(dependency)
 
         if mod.deprecated_at
+          exit_code |= 2
           if mod.superseded_by
             puts "  #{dependency} was superseded by #{mod.superseded_by[:slug]}"
           elsif mod.deprecated_for
@@ -99,10 +102,13 @@ module MetadataJsonDeps
               puts "  #{dependency} (#{constraint}) matches #{current}"
             end
           else
+            exit_code |= 1
             puts "  #{dependency} (#{constraint}) doesn't match #{current}"
           end
         end
       end
+
+      exit_code
     end
   rescue Interrupt
   end


### PR DESCRIPTION
If there are unmet dependencies or deprecated modules the script and rake task should fail. This implements an exit code. 1 means unmet dependencies, 2 means deprecated modules. Since they're ORed 3 means both unmet dependencies and deprecated modules. If there's another condition it should use code 4.