### PR TITLE
puppet_forge: Allow 4.x

### DIFF
--- a/metadata_json_deps.gemspec
+++ b/metadata_json_deps.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   # puppet_forge requires Ruby 2.4
   s.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
-  s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 4'
+  s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 5'
   s.add_runtime_dependency 'puppet_metadata', '>= 0.3.0', '< 2'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
that version was released a few hours ago.