### PR TITLE
Catch Faraday::ResourceNotFound when a module is missing on forge.puppet.com

### DIFF
--- a/lib/metadata_json_deps.rb
+++ b/lib/metadata_json_deps.rb
@@ -9,7 +9,11 @@ module MetadataJsonDeps
 
     def get_module(name)
       name = PuppetForge::V3.normalize_name(name)
-      @cache[name] ||= PuppetForge::Module.find(name)
+      begin
+        @cache[name] ||= PuppetForge::Module.find(name)
+      rescue Faraday::ResourceNotFound
+        raise PuppetForge::ModuleNotFound.new("Dependency #{name} not found on forge.puppet.com")
+      end
     end
   end
 


### PR DESCRIPTION
Hi!
I saw this in a CI:
```
Run bundle exec rake metadata_deps
Checking site/profiles/metadata.json
rake aborted!
Faraday::ResourceNotFound: the server responded with status [4](https://github.com/voxpupuli/controlrepo/actions/runs/4829384220/jobs/8604361742#step:9:5)04
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/response/raise_error.rb:22:in `on_complete'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/middleware.rb:19:in `block in call'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/response.rb:61:in `on_complete'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/middleware.rb:18:in `call'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/follow_redirects.rb:79:in `perform_with_redirection'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/follow_redirects.rb:67:in `call'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:1[5](https://github.com/voxpupuli/controlrepo/actions/runs/4829384220/jobs/8604361742#step:9:6)4:in `build_response'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/connection.rb:51[6](https://github.com/voxpupuli/controlrepo/actions/runs/4829384220/jobs/8604361742#step:9:7):in `run_request'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/puppet_forge-3.2.0/lib/puppet_forge/v3/base.rb:69:in `request'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/puppet_forge-3.2.0/lib/puppet_forge/v3/base.rb:[7](https://github.com/voxpupuli/controlrepo/actions/runs/4829384220/jobs/8604361742#step:9:8)6:in `find_request'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/puppet_forge-3.2.0/lib/puppet_forge/v3/base.rb:[8](https://github.com/voxpupuli/controlrepo/actions/runs/4829384220/jobs/8604361742#step:9:9)2:in `find'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/metadata_json_deps-1.0.0/lib/metadata_json_deps.rb:12:in `get_module'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/metadata_json_deps-1.0.0/lib/metadata_json_deps.rb:84:in `block (2 levels) in run'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/metadata_json_deps-1.0.0/lib/metadata_json_deps.rb:83:in `each'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/metadata_json_deps-1.0.0/lib/metadata_json_deps.rb:83:in `map'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/metadata_json_deps-1.0.0/lib/metadata_json_deps.rb:83:in `block in run'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/metadata_json_deps-1.0.0/lib/metadata_json_deps.rb:7[9](https://github.com/voxpupuli/controlrepo/actions/runs/4829384220/jobs/8604361742#step:9:10):in `run'
/home/runner/work/controlrepo/controlrepo/Rakefile:15:in `block in <top (required)>'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/rake-[13](https://github.com/voxpupuli/controlrepo/actions/runs/4829384220/jobs/8604361742#step:9:14).0.6/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.1.4/x64/bin/bundle:[25](https://github.com/voxpupuli/controlrepo/actions/runs/4829384220/jobs/8604361742#step:9:26):in `load'
/opt/hostedtoolcache/Ruby/3.1.4/x64/bin/bundle:25:in `<main>'
Tasks: TOP => metadata_deps
(See full trace by running task with --trace)
Checking site/roles/metadata.json
```

that's not helpful and should maybe be fixed in `puppet_forge`, but a fix in metadata_json_deps is quicker to be implemented and won't hurt. With this patch we raise our own exception and print the wrong module. maybe we just want to log warning instead?

```
Exception: Dependency voxpupuli-profiles not found on forge.puppet.com
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c19[7](https://github.com/voxpupuli/controlrepo/actions/runs/4829453816/jobs/8604546269#step:9:8)4b/lib/metadata_json_deps.rb:15:in `rescue in get_module'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-[8](https://github.com/voxpupuli/controlrepo/actions/runs/4829453816/jobs/8604546269#step:9:9)d33a4c1[9](https://github.com/voxpupuli/controlrepo/actions/runs/4829453816/jobs/8604546269#step:9:10)74b/lib/metadata_json_deps.rb:12:in `get_module'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:88:in `block (2 levels) in run'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:87:in `each'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:87:in `map'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:87:in `block in run'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:83:in `run'
/home/runner/work/controlrepo/controlrepo/Rakefile:15:in `block in <top (required)>'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.1.4/x64/bin/bundle:25:in `load'
/opt/hostedtoolcache/Ruby/3.1.4/x64/bin/bundle:25:in `<main>'

Caused by:
Faraday::ResourceNotFound: the server responded with status 404
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.[10](https://github.com/voxpupuli/controlrepo/actions/runs/4829453816/jobs/8604546269#step:9:11).3/lib/faraday/response/raise_error.rb:22:in `on_complete'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/middleware.rb:19:in `block in call'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/response.rb:61:in `on_complete'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/middleware.rb:18:in `call'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response_middleware.rb:36:in `call'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/follow_redirects.rb:79:in `perform_with_redirection'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday_middleware-1.2.0/lib/faraday_middleware/response/follow_redirects.rb:67:in `call'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/puppet_forge-3.2.0/lib/puppet_forge/v3/base.rb:69:in `request'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/puppet_forge-3.2.0/lib/puppet_forge/v3/base.rb:76:in `find_request'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/puppet_forge-3.2.0/lib/puppet_forge/v3/base.rb:82:in `find'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:13:in `get_module'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:88:in `block (2 levels) in run'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:87:in `each'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:87:in `map'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:87:in `block in run'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/bundler/gems/metadata_json_deps-8d33a4c1974b/lib/metadata_json_deps.rb:83:in `run'
/home/runner/work/controlrepo/controlrepo/Rakefile:15:in `block in <top (required)>'
/home/runner/work/controlrepo/controlrepo/vendor/bundle/ruby/3.1.0/gems/rake-[13](https://github.com/voxpupuli/controlrepo/actions/runs/4829453816/jobs/8604546269#step:9:14).0.6/exe/rake:27:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.1.4/x64/bin/bundle:25:in `load'
/opt/hostedtoolcache/Ruby/3.1.4/x64/bin/bundle:25:in `<main>'
Tasks: TOP => metadata_deps
(See full trace by running task with --trace)
Checking site/roles/metadata.json
Error: Process completed with exit code 1.
```