### PR TITLE
Require Ruby 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "2.4"
-          - ruby: "2.5"
-          - ruby: "2.6"
-          - ruby: "2.7"
-          - ruby: "3.0"
           - ruby: "3.1"
           - ruby: "3.2"
           - ruby: "3.3"

--- a/metadata_json_deps.gemspec
+++ b/metadata_json_deps.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
   s.executables << 'generate-fixtures-yaml'
   s.executables << 'metadata-json-deps'
 
-  # puppet_forge requires Ruby 2.4
-  s.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
+  # puppet_forge 6 requires Ruby 3.1
+  s.required_ruby_version = '>= 3.1'
 
-  s.add_runtime_dependency 'puppet_forge', '>= 2.2', '< 6'
+  s.add_runtime_dependency 'puppet_forge', '~> 6.0'
   s.add_runtime_dependency 'puppet_metadata', '>= 0.3.0', '< 5'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
This allows us to use the latest version of puppet_forge.